### PR TITLE
Default format inline code

### DIFF
--- a/poly-markdown.el
+++ b/poly-markdown.el
@@ -65,7 +65,7 @@
   :tail-mode 'host)
 
 (define-innermode poly-markdown-inline-code-innermode
-  :head-matcher (cons "[^`]\\(`\\)[[:alnum:]+-]" 1)
+  :head-matcher (cons "[^`]\\(`\\)[[:alnum:]([{&*+-]" 1)
   :tail-matcher (cons "\\(`\\)[^`]" 1)
   :allow-nested nil
   :head-mode 'host

--- a/poly-markdown.el
+++ b/poly-markdown.el
@@ -64,10 +64,9 @@
   :head-mode 'host
   :tail-mode 'host)
 
-(define-auto-innermode poly-markdown-inline-code-innermode
-  :head-matcher (cons "[^`]\\(`{?[[:alpha:]+-]+\\)[ \t]" 1)
-  :tail-matcher (cons "[^`]\\(`\\)[^`]" 1)
-  :mode-matcher (cons "`[ \t]*{?\\(?:lang *= *\\)?\\([[:alpha:]+-]+\\)" 1)
+(define-innermode poly-markdown-inline-code-innermode
+  :head-matcher (cons "[^`]\\(`\\)[[:alnum:]+-]" 1)
+  :tail-matcher (cons "\\(`\\)[^`]" 1)
   :allow-nested nil
   :head-mode 'host
   :tail-mode 'host)


### PR DESCRIPTION
Instead of getting the format mode from the first word, use the default format.  This is the standard style in all code bases I've ever laid my eyes on.  It makes sense to implement here.