### PR TITLE
Load the definition of desktop-minor-mode-table

### DIFF
--- a/poly-markdown.el
+++ b/poly-markdown.el
@@ -35,6 +35,7 @@
 ;;
 ;;; Code:
 
+(eval-when-compile (require 'desktop)) ;; in define-polymode poly-markdown-mode
 (require 'polymode)
 (require 'markdown-mode)
 


### PR DESCRIPTION
It removes one byte-compiler warning.