### PR TITLE
[Fix #22] Allow extra = before the language symbol

### DIFF
--- a/poly-markdown.el
+++ b/poly-markdown.el
@@ -70,7 +70,7 @@
 (define-auto-innermode poly-markdown-fenced-code-innermode poly-markdown-root-innermode
   :head-matcher (cons "^[ \t]*\\(```[ \t]*{?[[:alpha:].=].*\n\\)" 1)
   :tail-matcher (cons "^[ \t]*\\(```\\)[ \t]*$" 1)
-  :mode-matcher (cons "```[ \t]*{?[\\.=]?\\(?:lang *= *\\)?\\([^ \t\n;=,}]+\\)" 1))
+  :mode-matcher (cons "```[ \t]*{?[.=]?\\(?:lang *= *\\)?\\([^ \t\n;=,}]+\\)" 1))
 
 ;; Intended to be inherited from by more specialized innermodes.
 ;; FIXME: Some font-lock issues on deletion.


### PR DESCRIPTION
Closes #22.
